### PR TITLE
Fix build

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -3,7 +3,7 @@ name: Python package
 on:
   push:
     branches:
-    - '**'
+    - master
     tags-ignore:
     - '**'
     paths-ignore:
@@ -15,49 +15,51 @@ on:
 
 jobs:
   build_wheels_linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
       with:
         submodules: 'true'
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.19.2
+      uses: pypa/cibuildwheel@v2.21.3
       env:
         CIBW_BEFORE_ALL: sh linux-build.sh
         CIBW_BEFORE_BUILD: ls {project}/libjpeg-turbo-build
-        CIBW_SKIP: cp36-* pp*
+        CIBW_SKIP: pp*
         CIBW_ARCHS_LINUX: auto64
         CIBW_REPAIR_WHEEL_COMMAND: LD_LIBRARY_PATH=/project/libjpeg-turbo-build auditwheel repair -w {dest_dir} {wheel}
         CIBW_BEFORE_TEST: python -m pip install -r requirements-dev.txt && python generate_test_images.py
         CIBW_TEST_COMMAND: cd {project} && python -m unittest discover -s tests
         CIBW_TEST_SKIP: '*-musllinux_*'
         CIBW_TEST_EXTRAS: test
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
-        path: ./wheelhouse/*.whl
+        name: artifact-wheels-ubuntu
+        path: wheelhouse/*.whl
 
   build_wheels_macos:
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
     - uses: actions/checkout@v4
       with:
         submodules: 'true'
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.19.2
+      uses: pypa/cibuildwheel@v2.21.3
       env:
         CIBW_BEFORE_ALL: sh macos-build.sh
         CIBW_BEFORE_BUILD: ls {project}/libjpeg-turbo-build
-        CIBW_SKIP: cp36-* pp*
+        CIBW_SKIP: pp*
         CIBW_REPAIR_WHEEL_COMMAND: DYLD_LIBRARY_PATH=./libjpeg-turbo-build delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
         CIBW_BEFORE_TEST: python -m pip install -r requirements-dev.txt && python generate_test_images.py
         CIBW_TEST_COMMAND: cd {project} && python -m unittest discover -s tests
         CIBW_TEST_EXTRAS: test
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
-        path: ./wheelhouse/*.whl
+        name: artifact-wheels-macos
+        path: wheelhouse/*.whl
 
   build_wheels_windows:
-    runs-on: windows-latest
+    runs-on: windows-2019
     strategy:
       matrix:
         arch:
@@ -84,31 +86,32 @@ jobs:
         nmake
         cd ..
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.19.2
+      uses: pypa/cibuildwheel@v2.21.3
       env:
-        CIBW_SKIP: cp36-* pp*
+        CIBW_SKIP: pp*
         CIBW_ARCHS_WINDOWS: ${{ matrix.arch }}
         CIBW_BEFORE_BUILD_WINDOWS: python -m pip install delvewheel
         CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: python -m delvewheel repair -w {dest_dir} {wheel} --add-path libjpeg-turbo-build --no-dll vcruntime140_1.dll;msvcp140.dll
         CIBW_BEFORE_TEST: python -m pip install -r requirements-dev.txt && python generate_test_images.py
         CIBW_TEST_COMMAND: cd /d {project} && python -m unittest discover -s tests
-        CIBW_TEST_SKIP: cp38-win32 cp39-win32 cp310-win32 cp311-win32 cp312-win32  # cp37-win32 has wheels!
+        CIBW_TEST_SKIP: cp38-win32 cp39-win32 cp310-win32 cp311-win32 cp312-win32 cp313-win32  # cp37-win32 has wheels!
         CIBW_TEST_EXTRAS: test
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
-        path: ./wheelhouse/*.whl
+        name: artifact-wheels-windows-${{ matrix.arch }}
+        path: wheelhouse/*.whl
 
   upload-pypi:
     if: github.event_name == 'release' && github.event.action == 'published'
     needs: [build_wheels_linux, build_wheels_macos, build_wheels_windows]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v4
       with:
-        name: artifact
+        pattern: artifact-*
         path: dist
-
+        merge-multiple: true
     - uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.6.0
+  rev: v5.0.0
   hooks:
   - id: check-added-large-files
   - id: check-case-conflict
+  - id: check-json
   - id: check-merge-conflict
   - id: check-symlinks
-  - id: check-json
   - id: check-toml
   - id: check-yaml
   - id: debug-statements
@@ -18,33 +18,39 @@ repos:
   - id: trailing-whitespace
     args: [--markdown-linebreak-ext=md]
 - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-  rev: v2.13.0
+  rev: v2.14.0
   hooks:
   - id: pretty-format-yaml
     args: [--autofix]
 - repo: https://github.com/tox-dev/pyproject-fmt
-  rev: 2.1.4
+  rev: 2.2.4
   hooks:
   - id: pyproject-fmt
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: v16.0.6
+  rev: v19.1.7
   hooks:
   - id: clang-format
 - repo: https://github.com/asottile/pyupgrade
   rev: v3.16.0
   hooks:
   - id: pyupgrade
-    args: [--py37-plus]
+    args: [--py38-plus]
 - repo: https://github.com/psf/black-pre-commit-mirror
-  rev: 24.4.2
+  rev: 24.8.0
   hooks:
   - id: black
 - repo: https://github.com/PyCQA/isort
   rev: 5.13.2
   hooks:
   - id: isort
+- repo: https://github.com/PyCQA/bandit
+  rev: 1.7.10
+  hooks:
+  - id: bandit
+    args: [-c, pyproject.toml]
+    additional_dependencies: ['.[toml]']
 - repo: https://github.com/pycqa/flake8
-  rev: 7.1.0
+  rev: 7.1.1
   hooks:
   - id: flake8
     additional_dependencies:

--- a/linux-build.sh
+++ b/linux-build.sh
@@ -3,7 +3,7 @@ yum -y install nasm devtoolset-11-gcc
 apk update
 apk add --upgrade gcc nasm
 python -m pip install -U pip wheel
-python -m pip install -U cmake
+python -m pip install -U 'cmake>=3.5,<4.0'
 mkdir libjpeg-turbo-build
 cd libjpeg-turbo-build
 cmake -G"Unix Makefiles" ../libjpeg-turbo

--- a/macos-build.sh
+++ b/macos-build.sh
@@ -1,7 +1,7 @@
 brew install nasm
 brew uninstall --ignore-dependencies jpeg-turbo
 python -m pip install -U pip wheel
-python -m pip install -U cmake
+python -m pip install -U 'cmake>=3.5,<4.0'
 mkdir libjpeg-turbo-build
 cd libjpeg-turbo-build
 cmake -G"Unix Makefiles" ../libjpeg-turbo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,37 @@ requires = [
   "setuptools>=42",
 ]
 
+[project]
+name = "turbojpeg"
+version = "0.0.2"
+description = "Python bindungs for libjpeg-turbo using pybind11"
+readme = "readme.md"
+license = { file = "LICENSE" }
+authors = [ { name = "Dobatymo" } ]
+requires-python = ">=3.7"
+classifiers = [
+  "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.7",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+]
+optional-dependencies.test = [
+  "numpy",
+  "pillow",
+  "scikit-image",
+]
+urls.Homepage = "https://github.com/Dobatymo/turbojpeg-python"
+
+[tool.setuptools]
+py-modules = [ "turbojpeg" ]
+
+[tool.cibuildwheel]
+dependency-versions = "pinned"
+
 [tool.black]
 line-length = 120
 

--- a/setup.py
+++ b/setup.py
@@ -14,23 +14,8 @@ ext_modules = [
     ),
 ]
 
-with open("readme.md", encoding="utf-8") as fr:
-    long_description = fr.read()
-
 setup(
-    name="turbojpeg",
-    version="0.0.2",
-    author="Dobatymo",
-    author_email="Dobatymo@users.noreply.github.com",
-    url="https://github.com/Dobatymo/turbojpeg-python",
-    description="Python bindungs for libjpeg-turbo using pybind11",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
     ext_modules=ext_modules,
     cmdclass={"build_ext": build_ext},
     zip_safe=False,
-    python_requires=">=3.7",
-    extras_require={
-        "test": ["Pillow", "numpy", "scikit-image"],
-    },
 )


### PR DESCRIPTION
CI build is broken. Possibly due to upgraded setuptools or pip.

Setting
```
[tool.cibuildwheel]
dependency-versions = "pinned"
```
fixes it. Although that should be the default anyway.

Building for 3.13 works, but testing does not succeed because building the test dependency scikit-image fails for windows and macos currently.

* pin runners
* update pre-commit
* move to pyproject